### PR TITLE
[Issue-14] Fix open link on selected track

### DIFF
--- a/src/components/PlayConfirmModal.vue
+++ b/src/components/PlayConfirmModal.vue
@@ -89,7 +89,7 @@ const artistName = computed(() => {
 function play() {
   let url = '';
   if (selectedTrack.value) {
-    url = selectedTrack.value.external_urls.spotify;
+    url = selectedTrack.value.album.external_urls.spotify;
   } else if (selectedAlbum.value) {
     url = selectedAlbum.value.external_urls.spotify;
   }


### PR DESCRIPTION
`closes #14 `


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the play functionality to correctly access the Spotify URL from the album of the selected track, ensuring a smoother playback experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->