### PR TITLE
[#32] Fix flaky PlayConfirmModal test

### DIFF
--- a/src/tests/components/PlayConfirmModal.spec.ts
+++ b/src/tests/components/PlayConfirmModal.spec.ts
@@ -3,15 +3,15 @@ import { describe, test, expect, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import PlayConfirmModal from '@/components/PlayConfirmModal.vue';
 import { generateAlbum, generateAlbums, generateTrack } from '../helpers';
-import { flashPromise } from '../utils';
 
 describe('PlayConfirmModal', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
-  test('renders correctly - selected album', () => {
+
+  test('renders correctly - selected album', async () => {
     const selectedAlbum = generateAlbum();
-    const { getByTestId, getByAltText } = render(PlayConfirmModal, {
+    const { getByAltText, getByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -24,17 +24,18 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
-    expect(getByTestId('play-confirm-modal-overlay')).toBeTruthy();
+    await findByTestId('play-confirm-modal-overlay');
     expect(getByAltText(selectedAlbum.name)).toBeTruthy();
     expect(getByTestId('play-confirm-modal-album-name').textContent).toContain(selectedAlbum.name);
     expect(getByTestId('play-confirm-modal-artist-name').textContent).toContain(
       selectedAlbum.artists[0].name
     );
   });
-  test('renders correctly - selected track', () => {
-    const selectedTrack = generateAlbum().tracks.items[0];
-    const { getByTestId, getByAltText } = render(PlayConfirmModal, {
+  test('renders correctly - selected track', async () => {
+    const selectedTrack = generateTrack();
+    const { getByAltText, getByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
+        stubs: { transition: false },
         plugins: [
           createTestingPinia({
             initialState: {
@@ -46,7 +47,7 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
-    expect(getByTestId('play-confirm-modal-overlay')).toBeTruthy();
+    await findByTestId('play-confirm-modal-overlay');
     expect(getByAltText(selectedTrack.album.name)).toBeTruthy();
     expect(getByTestId('play-confirm-modal-album-name').textContent).toContain(
       selectedTrack.album.name
@@ -63,7 +64,7 @@ describe('PlayConfirmModal', () => {
       writable: true
     });
     const selectedAlbum = generateAlbum();
-    const { getByTestId } = render(PlayConfirmModal, {
+    const { getByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -76,10 +77,10 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const playButton = getByTestId('play-confirm-modal-play-button');
     expect(playButton).toBeTruthy();
     await fireEvent.click(playButton);
-    await flashPromise();
     expect(location.href).toContain(selectedAlbum.external_urls.spotify);
   });
   test('functionality - play track', async () => {
@@ -89,8 +90,8 @@ describe('PlayConfirmModal', () => {
       },
       writable: true
     });
-    const selectedTrack = generateAlbum().tracks.items[0];
-    const { getByTestId } = render(PlayConfirmModal, {
+    const selectedTrack = generateTrack();
+    const { getByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -103,15 +104,15 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const playButton = getByTestId('play-confirm-modal-play-button');
     expect(playButton).toBeTruthy();
     await fireEvent.click(playButton);
-    await flashPromise();
     expect(location.href).toContain(selectedTrack.album.external_urls.spotify);
   });
   test('functionality - next album', async () => {
     const albums = generateAlbums(2);
-    const { getByTestId, getByAltText } = render(PlayConfirmModal, {
+    const { getByTestId, getByAltText, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -126,10 +127,10 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const nextButton = getByTestId('play-confirm-modal-next-button');
     expect(nextButton).toBeTruthy();
     await fireEvent.click(nextButton);
-    await flashPromise();
     expect(getByAltText(albums[1].name)).toBeTruthy();
     expect(getByTestId('play-confirm-modal-album-name').textContent).toContain(albums[1].name);
     expect(getByTestId('play-confirm-modal-artist-name').textContent).toContain(
@@ -138,7 +139,7 @@ describe('PlayConfirmModal', () => {
   });
   test('functionality - next track', async () => {
     const tracks = [generateTrack(), generateTrack()];
-    const { getByTestId, getByAltText } = render(PlayConfirmModal, {
+    const { getByTestId, getByAltText, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -153,10 +154,10 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const nextButton = getByTestId('play-confirm-modal-next-button');
     expect(nextButton).toBeTruthy();
     await fireEvent.click(nextButton);
-    await flashPromise();
     expect(getByAltText(tracks[1].album.name)).toBeTruthy();
     expect(getByTestId('play-confirm-modal-album-name').textContent).toContain(
       tracks[1].album.name
@@ -167,7 +168,7 @@ describe('PlayConfirmModal', () => {
   });
   test('functionality - close - album', async () => {
     const selectedAlbum = generateAlbum();
-    const { getByTestId, queryByTestId } = render(PlayConfirmModal, {
+    const { getByTestId, queryByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -181,15 +182,15 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const closeButton = getByTestId('play-confirm-modal-close-button');
     expect(closeButton).toBeTruthy();
     await fireEvent.click(closeButton);
-    await flashPromise();
     expect(queryByTestId('play-confirm-modal')).not.toBeTruthy();
   });
   test('functionality - close - track', async () => {
-    const selectedTrack = generateAlbum().tracks.items[0];
-    const { getByTestId, queryByTestId } = render(PlayConfirmModal, {
+    const selectedTrack = generateTrack();
+    const { getByTestId, queryByTestId, findByTestId } = render(PlayConfirmModal, {
       global: {
         plugins: [
           createTestingPinia({
@@ -206,10 +207,10 @@ describe('PlayConfirmModal', () => {
         ]
       }
     });
+    await findByTestId('play-confirm-modal-overlay');
     const closeButton = getByTestId('play-confirm-modal-close-button');
     expect(closeButton).toBeTruthy();
     await fireEvent.click(closeButton);
-    await flashPromise();
     expect(queryByTestId('play-confirm-modal')).not.toBeTruthy();
   });
 });


### PR DESCRIPTION
closes #32

This PR fixes the flaky test in `PlayConfirmModal.spec.ts`. The flakiness was introduced by the `generateAlbum().tracks.items[0]` where it might generate an empty array for tracks. This PR also replaces the `getByTestId` queries with a single `findByTestId` query first to avoid going too fast before the modal is able to render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for play confirmation modal by migrating to asynchronous test patterns and enhanced DOM waiting mechanisms.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->